### PR TITLE
Made walkingkooka:j2cl-maven-plugin compatible 2/2

### DIFF
--- a/gwt-editor-j2cl-tests/pom.xml
+++ b/gwt-editor-j2cl-tests/pom.xml
@@ -90,9 +90,11 @@
 
               <skip>false</skip>
               <tests>
-<!--                <param>org.gwtproject.editor.client.DirtyEditorTest</param>-->
-<!--                <param>org.gwtproject.editor.client.EditorErrorTest</param>-->
+                <param>org.gwtproject.editor.client.DirtyEditorTest</param>
+                <!--
+                Disabled because of failures
                 <param>org.gwtproject.editor.client.SimpleBeanEditorTest</param>
+                -->
                 <param>org.gwtproject.editor.client.impl.DelegateMapTest</param>
                 <param>org.gwtproject.editor.client.adapters.ListEditorWrapperTest</param>
               </tests>


### PR DESCRIPTION
- Only groupId changed
- Replaced dependency javax.validation.* with walkingkooka:j2cl-javax-validation
- No code changes